### PR TITLE
Add trading core modules and utilities

### DIFF
--- a/src/core/exchange_connector.py
+++ b/src/core/exchange_connector.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import uuid
+from typing import Dict, Optional
+
+
+class ExchangeConnector:
+    """Tiny wrapper simulating connectivity with an exchange API.
+
+    The implementation does not perform real HTTP requests.  Instead it keeps an
+    in-memory representation of orders which is sufficient for unit tests and
+    development without network access.
+    """
+
+    def __init__(self, api_url: str, logger: Optional[logging.Logger] = None) -> None:
+        self.api_url = api_url
+        self.logger = logger or logging.getLogger(__name__)
+        self._orders: Dict[str, Dict[str, object]] = {}
+
+    async def fetch_ticker(self, pair: str) -> float:
+        """Return a pseudo random price for ``pair``.
+
+        In a production ready bot this method would request the latest ticker
+        from the exchange.  Here we simply return a deterministic pseudo-random
+        value to keep the module functional offline.
+        """
+        await asyncio.sleep(0)
+        price = random.uniform(10, 100)
+        self.logger.debug("Fetched ticker for %s: %.2f", pair, price)
+        return price
+
+    async def send_order(
+        self, pair: str, direction: str, size: float, price: Optional[float] = None
+    ) -> str:
+        """Send an order to the (simulated) exchange and return its id."""
+        await asyncio.sleep(0)
+        order_id = str(uuid.uuid4())
+        self._orders[order_id] = {
+            "pair": pair,
+            "direction": direction,
+            "size": size,
+            "price": price,
+            "status": "OPEN",
+        }
+        self.logger.info(
+            "Order %s created: %s %.4f %s", order_id, direction, size, pair
+        )
+        return order_id
+
+    async def cancel_order(self, order_id: str) -> bool:
+        """Cancel an order by id."""
+        await asyncio.sleep(0)
+        order = self._orders.get(order_id)
+        if not order or order["status"] != "OPEN":
+            return False
+        order["status"] = "CANCELLED"
+        self.logger.info("Order %s cancelled", order_id)
+        return True
+
+    async def get_order(self, order_id: str) -> Optional[Dict[str, object]]:
+        await asyncio.sleep(0)
+        return self._orders.get(order_id)

--- a/src/core/order_manager.py
+++ b/src/core/order_manager.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from .exchange_connector import ExchangeConnector
+from .risk_manager import RiskManager
+
+
+class OrderManager:
+    """High level order management including optional risk checks."""
+
+    def __init__(
+        self, connector: ExchangeConnector, risk_manager: Optional[RiskManager] = None
+    ) -> None:
+        self.connector = connector
+        self.risk_manager = risk_manager
+        self.orders: Dict[str, Dict[str, object]] = {}
+
+    async def create_order(
+        self, pair: str, direction: str, size: float, price: Optional[float] = None
+    ) -> str:
+        """Create an order after verifying risk limits."""
+        if self.risk_manager and not self.risk_manager.check_order(pair, size):
+            raise ValueError("Risk check failed")
+        order_id = await self.connector.send_order(pair, direction, size, price)
+        self.orders[order_id] = {
+            "pair": pair,
+            "direction": direction,
+            "size": size,
+            "price": price,
+            "status": "OPEN",
+        }
+        if self.risk_manager:
+            self.risk_manager.register_order(pair, size)
+        return order_id
+
+    async def cancel_order(self, order_id: str) -> bool:
+        success = await self.connector.cancel_order(order_id)
+        if success and order_id in self.orders:
+            self.orders[order_id]["status"] = "CANCELLED"
+            if self.risk_manager:
+                self.risk_manager.unregister_order(
+                    self.orders[order_id]["pair"],
+                    self.orders[order_id]["size"],
+                )
+        return success
+
+    def get_order(self, order_id: str) -> Optional[Dict[str, object]]:
+        return self.orders.get(order_id)

--- a/src/core/portfolio_tracker.py
+++ b/src/core/portfolio_tracker.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Dict
+
+
+class PortfolioTracker:
+    """Track account balances and positions in memory."""
+
+    def __init__(self) -> None:
+        self.balances: Dict[str, float] = {}
+        self.positions: Dict[str, float] = {}
+
+    def update_balance(self, asset: str, amount: float) -> None:
+        self.balances[asset] = self.balances.get(asset, 0.0) + amount
+
+    def get_balance(self, asset: str) -> float:
+        return self.balances.get(asset, 0.0)
+
+    def update_position(self, pair: str, size: float) -> None:
+        self.positions[pair] = self.positions.get(pair, 0.0) + size
+
+    def get_position(self, pair: str) -> float:
+        return self.positions.get(pair, 0.0)

--- a/src/core/risk_manager.py
+++ b/src/core/risk_manager.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Dict
+
+
+class RiskManager:
+    """Basic risk control features including a kill switch."""
+
+    def __init__(self, max_position: float = float("inf")) -> None:
+        self.max_position = max_position
+        self.kill_switch = False
+        self._positions: Dict[str, float] = {}
+
+    def check_order(self, pair: str, size: float) -> bool:
+        """Return ``True`` if placing an order of ``size`` is allowed."""
+        if self.kill_switch:
+            return False
+        current = self._positions.get(pair, 0.0)
+        return current + size <= self.max_position
+
+    def register_order(self, pair: str, size: float) -> None:
+        self._positions[pair] = self._positions.get(pair, 0.0) + size
+
+    def unregister_order(self, pair: str, size: float) -> None:
+        self._positions[pair] = self._positions.get(pair, 0.0) - size
+
+    def activate_kill_switch(self) -> None:
+        self.kill_switch = True
+
+    def deactivate_kill_switch(self) -> None:
+        self.kill_switch = False
+
+    def check_stop(self, price: float, stop_price: float) -> bool:
+        """Return ``True`` when the stop should trigger."""
+        return price <= stop_price

--- a/src/strategies/semi_auto_strategy.py
+++ b/src/strategies/semi_auto_strategy.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from ..core.order_manager import OrderManager
+from ..core.risk_manager import RiskManager
+from .trailing_stop import TrailingStop
+
+
+class SemiAutoStrategy:
+    """Simple semi-automatic trading strategy.
+
+    Orders are created manually through method calls but the strategy maintains
+    optional trailing stops and respects the global kill switch exposed by the
+    :class:`~src.core.risk_manager.RiskManager`.
+    """
+
+    def __init__(self, order_manager: OrderManager, risk_manager: RiskManager) -> None:
+        self.order_manager = order_manager
+        self.risk_manager = risk_manager
+        self._trailing: Dict[str, TrailingStop] = {}
+
+    async def open_trade(
+        self, pair: str, direction: str, size: float, trail: Optional[float] = None
+    ) -> str:
+        if self.risk_manager.kill_switch:
+            raise RuntimeError("Kill switch active")
+        order_id = await self.order_manager.create_order(pair, direction, size)
+        if trail is not None:
+            self._trailing[order_id] = TrailingStop(trail)
+        return order_id
+
+    async def on_price(self, order_id: str, price: float) -> bool:
+        """Update trailing stop with the latest ``price``.
+
+        Returns ``True`` if the trailing stop triggers and the order is cancelled.
+        """
+        ts = self._trailing.get(order_id)
+        if not ts:
+            return False
+        stop = ts.update(price)
+        if ts.hit(price) and self.risk_manager.check_stop(price, stop):
+            await self.order_manager.cancel_order(order_id)
+            self._trailing.pop(order_id, None)
+            return True
+        return False
+
+    async def close_trade(self, order_id: str) -> None:
+        await self.order_manager.cancel_order(order_id)
+        self._trailing.pop(order_id, None)

--- a/src/strategies/trailing_stop.py
+++ b/src/strategies/trailing_stop.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Optional
+
+
+class TrailingStop:
+    """Maintain a trailing stop price for an open position."""
+
+    def __init__(self, distance: float) -> None:
+        self.distance = distance
+        self._peak: float = float("-inf")
+        self._stop: Optional[float] = None
+
+    def update(self, price: float) -> float:
+        """Update internal state with the latest ``price`` and return the stop."""
+        if price > self._peak:
+            self._peak = price
+            self._stop = price - self.distance
+        elif self._stop is None:
+            self._stop = price - self.distance
+        return self._stop
+
+    def hit(self, price: float) -> bool:
+        """Return ``True`` if the trailing stop would trigger at ``price``."""
+        return self._stop is not None and price <= self._stop

--- a/src/ui/alerts.py
+++ b/src/ui/alerts.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import logging
+from typing import Callable, List, Optional
+
+
+class AlertService:
+    """Dispatch textual alerts to subscribed callbacks and the log."""
+
+    def __init__(self, logger: Optional[logging.Logger] = None) -> None:
+        self.logger = logger or logging.getLogger(__name__)
+        self._subs: List[Callable[[str], None]] = []
+
+    def subscribe(self, callback: Callable[[str], None]) -> None:
+        self._subs.append(callback)
+
+    async def send(self, message: str) -> None:
+        self.logger.warning("ALERT: %s", message)
+        for cb in list(self._subs):
+            try:
+                cb(message)
+            except Exception:  # pragma: no cover - defensive logging
+                self.logger.exception("Alert subscriber failed")

--- a/src/ui/dashboard.py
+++ b/src/ui/dashboard.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from ..core.order_manager import OrderManager
+from ..core.portfolio_tracker import PortfolioTracker
+from .alerts import AlertService
+
+
+class Dashboard:
+    """Very small textual dashboard for the trading bot."""
+
+    def __init__(
+        self,
+        portfolio: PortfolioTracker,
+        orders: OrderManager,
+        alerts: Optional[AlertService] = None,
+    ) -> None:
+        self.portfolio = portfolio
+        self.orders = orders
+        self.alerts = alerts
+
+    async def render(self) -> str:
+        balances = ", ".join(
+            f"{asset}: {amount:.2f}" for asset, amount in self.portfolio.balances.items()
+        ) or "no balances"
+        open_orders = [o for o in self.orders.orders.values() if o.get("status") == "OPEN"]
+        dashboard = f"Balances: {balances} | Open orders: {len(open_orders)}"
+        if self.alerts:
+            await self.alerts.send("Dashboard refreshed")
+        return dashboard

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Config:
+    """Application configuration loaded from a file or environment variables."""
+
+    api_url: str = "https://extended.exchange/api"
+    max_position: float = 10.0
+    log_level: str = "INFO"
+    kill_switch: bool = False
+
+
+def _parse_bool(value: str) -> bool:
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def load_config(path: Optional[str] = None) -> Config:
+    """Load configuration from ``path`` overriding values with environment variables."""
+
+    data: dict[str, object] = {}
+    if path and os.path.exists(path):
+        with open(path) as f:
+            data.update(json.load(f))
+
+    api_url = os.getenv("API_URL", data.get("api_url", Config.api_url))
+    max_position = float(
+        os.getenv("MAX_POSITION", data.get("max_position", Config.max_position))
+    )
+    log_level = os.getenv("LOG_LEVEL", data.get("log_level", Config.log_level))
+    kill_switch = os.getenv(
+        "KILL_SWITCH", str(data.get("kill_switch", Config.kill_switch))
+    )
+
+    return Config(
+        api_url=api_url,
+        max_position=max_position,
+        log_level=log_level,
+        kill_switch=_parse_bool(str(kill_switch)),
+    )

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -1,0 +1,23 @@
+import logging
+import sys
+from typing import Optional
+
+
+def get_logger(name: str, level: str = "INFO", stream: Optional[object] = None) -> logging.Logger:
+    """Return a configured :class:`logging.Logger` instance.
+
+    The function ensures that loggers are configured in a consistent way across
+    the project. Handlers are only added once which makes the function safe to
+    call multiple times.  By default logs are written to ``stdout``.
+    """
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler(stream or sys.stdout)
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.propagate = False
+    logger.setLevel(level.upper())
+    return logger

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict
+
+
+class MetricsCollector:
+    """Collect in-memory metrics for the bot.
+
+    The implementation is intentionally lightweight. Metrics are stored in
+    dictionaries and can be exported for display on the dashboard or sent to an
+    external system if required.
+    """
+
+    def __init__(self) -> None:
+        self.counters: Dict[str, int] = defaultdict(int)
+        self.gauges: Dict[str, float] = {}
+
+    def increment(self, name: str, value: int = 1) -> None:
+        self.counters[name] += value
+
+    def set_gauge(self, name: str, value: float) -> None:
+        self.gauges[name] = value
+
+    def snapshot(self) -> Dict[str, Dict[str, float]]:
+        """Return a copy of all collected metrics."""
+        return {"counters": dict(self.counters), "gauges": dict(self.gauges)}


### PR DESCRIPTION
## Summary
- implement exchange connector with basic order simulation
- add order manager, risk manager, portfolio tracker
- create semi-auto strategy with trailing stop management
- provide alerts/dashboard UI and configuration/logger/metrics utilities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689332f8e29c8330b74846e5fc0cfdd4