### PR TITLE
Remove id and status from TradeCreate schema

### DIFF
--- a/src/database/repositories.py
+++ b/src/database/repositories.py
@@ -1,5 +1,7 @@
 # src/database/repositories.py
 from typing import List
+import uuid
+from datetime import datetime
 
 from sqlalchemy import select
 
@@ -12,7 +14,12 @@ class TradeRepository:
     
     async def create_trade(self, trade_data: TradeCreate) -> Trade:
         trade_dict = trade_data.model_dump()
-        trade = Trade(**trade_dict)
+        trade = Trade(
+            id=str(uuid.uuid4()),
+            status="ACTIVE",
+            created_at=datetime.utcnow(),
+            **trade_dict,
+        )
         self.session.add(trade)
         await self.session.commit()
         await self.session.refresh(trade)

--- a/src/database/schemas.py
+++ b/src/database/schemas.py
@@ -3,11 +3,9 @@ from datetime import datetime
 from typing import Optional
 
 class TradeCreate(BaseModel):
-    id: str
     pair: str
     direction: str
     size: float
-    status: str
     entry_price: Optional[float] = None
     tp_price: Optional[float] = None
     sl_price: Optional[float] = None

--- a/tests/test_trade_repository.py
+++ b/tests/test_trade_repository.py
@@ -23,14 +23,13 @@ async def test_create_and_get_active_trade():
     async with AsyncSessionLocal() as session:
         repo = TradeRepository(session)
         trade_data = TradeCreate(
-            id="t1",
             pair="BTC/USDT",
             direction="LONG",
             size=1.0,
-            status="ACTIVE",
         )
         await repo.create_trade(trade_data)
 
         active_trades = await repo.get_active_trades()
         assert len(active_trades) == 1
-        assert active_trades[0].id == "t1"
+        assert active_trades[0].status == "ACTIVE"
+        assert active_trades[0].id is not None


### PR DESCRIPTION
## Summary
- simplify TradeCreate schema by removing id and status
- generate UUIDs and default status in TradeRepository
- update tests for new trade creation flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689360232fc4833096c1ac4f26b58e73